### PR TITLE
Fix bugs in guidance system

### DIFF
--- a/app/assets/javascripts/modules/lpa.help-system.js
+++ b/app/assets/javascripts/modules/lpa.help-system.js
@@ -105,13 +105,13 @@
       // Set nav item as active
       $('.help-navigation a[href$="#' + slug + '"]').parent() // use 'ends with' selector so don't have to define url slug
         .addClass('active')
-        .siblings()
+        .siblings('li')
         .removeClass('active');
 
       // Show associated content
       $('#' + slug)
         .removeClass('hidden')
-        .siblings()
+        .siblings('article')
         .addClass('hidden');
 
       // Scroll back to top of help

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -21,6 +21,6 @@ module ContentHelper
   end
 
   def guidance_link (label, section_id)
-    link_to label, "#{guidance_path}##{section_id}", {:class => 'js-guidance', "data-journey-click" => "stageprompt.lpa:help:#{section_id}" }
+    link_to label, "#{guidance_path}#section-#{section_id}", {:class => 'js-guidance', "data-journey-click" => "stageprompt.lpa:help:#{section_id}" }
   end
 end

--- a/app/views/content/guidance.html.haml
+++ b/app/views/content/guidance.html.haml
@@ -13,7 +13,7 @@
     .content.help-sections
       - debug(@sections)
       - @sections.each do |id, content|
-        %article{:id => id}
+        %article{:id => "section-#{id}"}
           = raw content
 
     .action.group


### PR DESCRIPTION
Make sure the siblings call only looks for the right element.
Add prefix for sections to avoid ID conflicts.
