### PR TITLE
Email confirmation on signup

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,9 @@
 API_HOST=http://localhost:9292
 RAILS_ENV=development
+
+HOST=http://localhost:9292
+SENDER_EMAIL=an@example.com
+CONTACT_PHONE=0000 000 0000
+CONTACT_EMAIL=contact@example.com
+CONTACT_ADDRESS=PO Box 111
+SITE_URL=localhost

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -15,6 +15,7 @@ class Users::RegistrationsController < ApplicationController
     response = ApiClient.post('/auth/users', body: @registration.credentials)
 
     if response.code == 201
+      SignUpConfirmer.signup_email(@registration.email)
       # success
     else
       set_validation_messages response, @registration

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -15,8 +15,7 @@ class Users::RegistrationsController < ApplicationController
     response = ApiClient.post('/auth/users', body: @registration.credentials)
 
     if response.code == 201
-      SignUpConfirmer.signup_email(@registration.email)
-      # success
+      SignUpConfirmer.signup_email(@registration.email).deliver
     else
       set_validation_messages response, @registration
       render :template => '/users/registrations/new'

--- a/app/mailers/sign_up_confirmer.rb
+++ b/app/mailers/sign_up_confirmer.rb
@@ -1,0 +1,8 @@
+class SignUpConfirmer < ActionMailer::Base
+  default from: ENV['SENDER_EMAIL']
+
+  def signup_email(applicant_email)
+    @confirmation_url = "#{ENV['HOST']}/"
+    mail(to: applicant_email, subject: 'Activate your Lasting Power of Attorney registration')
+  end
+end

--- a/app/mailers/sign_up_confirmer.rb
+++ b/app/mailers/sign_up_confirmer.rb
@@ -2,7 +2,7 @@ class SignUpConfirmer < ActionMailer::Base
   default from: ENV['SENDER_EMAIL']
 
   def signup_email(applicant_email)
-    @confirmation_url = "#{ENV['HOST']}/"
+    @confirmation_url = "https://#{ENV['SITE_URL']}/todo"
     mail(to: applicant_email, subject: 'Activate your Lasting Power of Attorney registration')
   end
 end

--- a/app/views/sign_up_confirmer/signup_email.html.haml
+++ b/app/views/sign_up_confirmer/signup_email.html.haml
@@ -37,4 +37,4 @@
 
     %p= ENV['CONTACT_ADDRESS']
     %p
-      %a{ href: ENV['SITE_URL'] }= ENV['SITE_URL']
+      %a{ href: "https://#{ENV['SITE_URL']}" }= ENV['SITE_URL']

--- a/app/views/sign_up_confirmer/signup_email.html.haml
+++ b/app/views/sign_up_confirmer/signup_email.html.haml
@@ -1,0 +1,40 @@
+%html
+  %head
+  %body
+    %p Thank you for registering to use the digital LPA tool.
+
+    %p
+      %strong Use this link to activate and start using your account:
+
+    %div{ style: 'width:500px;margin-left:40px' }
+      %a{ href: @confirmation_url }= @confirmation_url
+
+    %p
+      If the link doesn't work, copy it into your browser's address bar.  The link will expire in 24 hours.
+
+    %p
+      %strong You must activate your account before you can create a lasting power of attorney (LPA).
+
+    %p
+      You must activate your account within 24 hours. If you don't, the account will be automatically deleted and you'll have to register again.
+
+    %p
+      This is an automatic email - please don't reply to this address. If you need to contact us you can:
+
+    %div
+      %p
+        Call
+        %strong= ENV['CONTACT_PHONE']
+      %p
+        Email
+        %a{ href: "mailto:#{ENV['CONTACT_EMAIL']}"}= ENV['CONTACT_EMAIL']
+
+      %br
+      %br
+
+    %p
+      %strong{ style: "font-size:1.2em" } Office of the Public Guardian
+
+    %p= ENV['CONTACT_ADDRESS']
+    %p
+      %a{ href: ENV['SITE_URL'] }= ENV['SITE_URL']

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -5,13 +5,24 @@ describe Users::RegistrationsController do
   describe 'create' do
 
     context 'when successful' do
-      it 'should send email' do
-        email = 'ex@ample.com'
-
+      before do
+        @applicant_email_address = 'ex@ample.com'
         ApiClient.stub(:post).and_return double(code: 201)
+      end
 
-        SignUpConfirmer.should_receive(:signup_email).with email
-        get :create, registration: { email: email, password: 'password' }
+      def get_create
+        get :create, registration: { email: @applicant_email_address, password: 'password' }
+      end
+
+      it 'should create email with applicant email address' do
+        SignUpConfirmer.should_receive(:signup_email).with(@applicant_email_address).and_return double(deliver: nil)
+        get_create
+      end
+
+      it 'should send email' do
+        ActionMailer::Base.deliveries.should be_empty
+        get_create
+        ActionMailer::Base.deliveries.should_not be_empty
       end
     end
   end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Users::RegistrationsController do
+
+  describe 'create' do
+
+    context 'when successful' do
+      it 'should send email' do
+        email = 'ex@ample.com'
+
+        ApiClient.stub(:post).and_return double(code: 201)
+
+        SignUpConfirmer.should_receive(:signup_email).with email
+        get :create, registration: { email: email, password: 'password' }
+      end
+    end
+  end
+end

--- a/spec/fixtures/sign_up_confirmer/signup_email
+++ b/spec/fixtures/sign_up_confirmer/signup_email
@@ -1,0 +1,43 @@
+<html>
+<head></head>
+<body>
+<p>Thank you for registering to use the digital LPA tool.</p>
+<p>
+<strong>Use this link to activate and start using your account:</strong>
+</p>
+<div style='width:500px;margin-left:40px'>
+<a href='https://testhost/todo'>https://testhost/todo</a>
+</div>
+<p>
+If the link doesn't work, copy it into your browser's address bar.  The link will expire in 24 hours.
+</p>
+<p>
+<strong>You must activate your account before you can create a lasting power of attorney (LPA).</strong>
+</p>
+<p>
+You must activate your account within 24 hours. If you don't, the account will be automatically deleted and you'll have to register again.
+</p>
+<p>
+This is an automatic email - please don't reply to this address. If you need to contact us you can:
+</p>
+<div>
+<p>
+Call
+<strong>0000 000 0000</strong>
+</p>
+<p>
+Email
+<a href='mailto:contact@testhost'>contact@testhost</a>
+</p>
+<br>
+<br>
+</div>
+<p>
+<strong style='font-size:1.2em'>Office of the Public Guardian</strong>
+</p>
+<p>PO Box 123</p>
+<p>
+<a href='https://testhost'>testhost</a>
+</p>
+</body>
+</html>

--- a/spec/mailers/sign_up_confirmer_spec.rb
+++ b/spec/mailers/sign_up_confirmer_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe SignUpConfirmer do
+
+  def read_fixture(action)
+    IO.readlines(File.dirname(__FILE__) + "/../fixtures/sign_up_confirmer/signup_email").join
+  end
+
+  describe 'signup_email' do
+
+    before do
+      @applicant_email = 'applicant@example.com'
+      @email = SignUpConfirmer.signup_email(@applicant_email).deliver
+    end
+
+    it 'should have correct "from" field' do
+      sender_email = ENV['SENDER_EMAIL']
+      sender_email_address = sender_email.sub("'Sender' <",'').chomp('>')
+
+      @email.from.should == [ sender_email_address ]
+      @email.to_s.should include( sender_email )
+    end
+
+    it 'should have correct "to" field' do
+      @email.to.should == [ @applicant_email ]
+    end
+
+    it 'should have correct body' do
+      @email.body.to_s.should == read_fixture('signup_email')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,12 @@
 ENV["RAILS_ENV"] ||= 'test'
 ENV['API_HOST'] ||= 'http://localhost:9292'
 
+ENV['SENDER_EMAIL'] ||= "'Sender' <sender@testhost>"
+ENV['SITE_URL'] ||= "testhost"
+ENV['CONTACT_PHONE'] ||= "0000 000 0000"
+ENV['CONTACT_EMAIL'] ||= "contact@testhost"
+ENV['CONTACT_ADDRESS'] ||= "PO Box 123"
+
 unless ENV['HOME'].to_s[/\/Users/]
   # Coveralls for code coverage on Travis builds
   require 'coveralls'
@@ -61,6 +67,8 @@ RSpec.configure do |config|
     name = example.metadata[:full_description].split(/\s+/, 2).join("/").underscore.gsub(/[^\w\/]+/, "_")
     VCR.use_cassette(name) { example.call }
   end
+
+  config.before(:each) { ActionMailer::Base.deliveries.clear }
 end
 
 def fill_in_valid_person(overrides={})


### PR DESCRIPTION
- Send signup confirmation email on successful sign up
- Contact details are configured in environment variables
- TODO: handle when the applicant clicks on the confirmation url contained in the email
